### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/vervocity/eslint-config.git"
+        "url": "git+https://github.com/vervocity/eslint-config.git"
     },
     "author": "Brandon Bloodgood",
     "license": "ISC",


### PR DESCRIPTION
## Summary
- update the package repository URL from the legacy git protocol to the public HTTPS Git URL
- leave runtime code, dependencies, package version, entry point, homepage, bugs metadata, and package contents unchanged

## Validation
- `npm view @vervocity/eslint-config --json`
- metadata assertion with Node.js
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run lint`
- `npm run prettier`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
